### PR TITLE
Add v3.10 main and community repos earlier in provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This builds an up-to-date Vagrant Alpine Linux Base Box.
 
-Currently this targets [Alpine Linux](https://alpinelinux.org/) 3.10.
+Currently this targets [Alpine Linux](https://alpinelinux.org/) 3.10.1.
 
 
 # Usage

--- a/alpine.json
+++ b/alpine.json
@@ -1,9 +1,9 @@
 {
   "variables": {
     "disk_size": "20480",
-    "version": "3.10",
-    "iso_url": "http://dl-cdn.alpinelinux.org/alpine/v3.10/releases/x86_64/alpine-standard-3.10.0-x86_64.iso",
-    "iso_checksum": "9b14a14689fb837e113216319538bc20d2e0640c01da4622db62f9fc51ff4bd1",
+    "version": "3.10.1",
+    "iso_url": "http://dl-cdn.alpinelinux.org/alpine/v3.10/releases/x86_64/alpine-standard-3.10.1-x86_64.iso",
+    "iso_checksum": "b51d81b40d94251b3940a48cd6f3801f9fcca12fbf95c3e29a43977a6004e460",
     "iso_checksum_type": "sha256"
   },
   "builders": [

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = 'alpine-3.10-amd64'
+  config.vm.box = 'alpine-3.10.1-amd64'
 
   config.vm.hostname = 'example'
 

--- a/provision.sh
+++ b/provision.sh
@@ -4,7 +4,11 @@ set -eu
 # echo all the executed commands.
 set -x
 
+echo -e "http://dl-cdn.alpinelinux.org/alpine/v3.10/main\n" >> /etc/apk/repositories
+echo -e "http://dl-cdn.alpinelinux.org/alpine/v3.10/community\n" >> /etc/apk/repositories
+
 # upgrade all packages.
+apk update
 apk upgrade -U --available
 
 # add the vagrant user and let it use root permissions without sudo asking for a password.
@@ -27,7 +31,7 @@ chown -R vagrant:vagrant /home/vagrant/.ssh
 # install the Guest Additions.
 if [ "$(cat /sys/devices/virtual/dmi/id/board_name)" == 'VirtualBox' ]; then
 # install the VirtualBox Guest Additions.
-echo http://mirrors.dotsrc.org/alpine/v3.10/community >>/etc/apk/repositories
+
 apk add -U virtualbox-guest-additions virtualbox-guest-modules-vanilla
 rc-update add virtualbox-guest-additions
 echo vboxsf >>/etc/modules
@@ -46,6 +50,9 @@ fi
 
 # install the nfs client to support nfs synced folders in vagrant.
 apk add nfs-utils
+
+# install DHCP client to aid in connectivity
+apk add dhclient
 
 # disable the DNS reverse lookup on the SSH server. this stops it from
 # trying to resolve the client IP address into a DNS domain name, which


### PR DESCRIPTION
* Also install dhclient for some DHCP action

These are a couple of changes I'm suggesting.

After the image is ready, if your Vagrantfile config or VirtualBox network preferences aren't quite right, it's possible to run into network connectivity issues, which for me necessitates opening up a VNC to troubleshoot. Further, you can't do much except set a static IP without DHCP, so having dhclient really comes in handy. 

Secondly, I suggest we work from the latest packages available on the main download mirror (though not edge or testing... but cdrom/main is bound to be somewhat behind).  