### PR TITLE
Update to Alpine 3.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ build-virtualbox: alpine-${VERSION}-amd64-virtualbox.box
 
 alpine-${VERSION}-amd64-libvirt.box: answers provision.sh alpine.json Vagrantfile.template
 	rm -f alpine-${VERSION}-amd64-libvirt.box
-	PACKER_KEY_INTERVAL=10ms packer build -only=alpine-${VERSION}-amd64-libvirt -on-error=abort alpine.json
+	PACKER_KEY_INTERVAL=10ms packer build -force -only=alpine-${VERSION}-amd64-libvirt -on-error=ask alpine.json
 	@echo BOX successfully built!
 	@echo to add to local vagrant install do:
 	@echo vagrant box add -f alpine-${VERSION}-amd64 alpine-${VERSION}-amd64-libvirt.box
 
 alpine-${VERSION}-amd64-virtualbox.box: answers provision.sh alpine.json Vagrantfile.template
 	rm -f alpine-${VERSION}-amd64-virtualbox.box
-	packer build -only=alpine-${VERSION}-amd64-virtualbox -on-error=abort alpine.json
+	packer build -force -only=alpine-${VERSION}-amd64-virtualbox -on-error=ask alpine.json
 	@echo BOX successfully built!
 	@echo to add to local vagrant install do:
 	@echo vagrant box add -f alpine-${VERSION}-amd64 alpine-${VERSION}-amd64-virtualbox.box

--- a/alpine.json
+++ b/alpine.json
@@ -143,10 +143,10 @@
   ],
   "variables": {
     "disk_size": "20480",
-    "iso_checksum": "c197f9cf095178d5ae978a47597a4004c16c879d2047b9906f91642cb01c2ef9",
+    "iso_checksum": "4b86ecf703464c47e53655d1969b74d5d2f2f8ed4b77002fa7c510d7b8bdc554",
     "iso_checksum_type": "sha256",
-    "iso_url": "http://dl-cdn.alpinelinux.org/alpine/v3.13/releases/x86_64/alpine-standard-3.13.0-x86_64.iso",
-    "version": "3.13"
+    "iso_url": "http://dl-cdn.alpinelinux.org/alpine/v3.13/releases/x86_64/alpine-standard-3.13.2-x86_64.iso",
+    "version": "3.13.2"
   }
 }
 

--- a/alpine.json
+++ b/alpine.json
@@ -1,36 +1,10 @@
 {
-  "variables": {
-    "disk_size": "20480",
-    "version": "3.12",
-    "iso_url": "http://dl-cdn.alpinelinux.org/alpine/v3.12/releases/x86_64/alpine-standard-3.12.0-x86_64.iso",
-    "iso_checksum": "746a7af837fcb3451b7587e881d6706269cf4f300f7cf37964e200e50a52c93c",
-    "iso_checksum_type": "sha256"
-  },
   "builders": [
     {
-      "name": "alpine-{{user `version`}}-amd64-libvirt",
-      "type": "qemu",
       "accelerator": "kvm",
-      "qemuargs": [
-        ["-m", "2048"],
-        ["-smp", "2"]
-      ],
-      "headless": true,
-      "http_directory": ".",
-      "format": "qcow2",
-      "disk_size": "{{user `disk_size`}}",
-      "disk_interface": "virtio-scsi",
-      "disk_discard": "unmap",
-      "iso_url": "{{user `iso_url`}}",
-      "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "{{user `iso_checksum_type`}}",
-      "ssh_username": "root",
-      "ssh_password": "vagrant",
-      "ssh_wait_timeout": "60m",
-      "boot_wait": "30s",
       "boot_command": [
         "root<enter>",
-        "ifconfig eth0 up && udhcpc -i eth0<enter><wait5>",
+        "ifconfig eth0 up \u0026\u0026 udhcpc -i eth0<enter><wait5>",
         "wget -q http://{{.HTTPIP}}:{{.HTTPPort}}/answers<enter><wait>",
         "setup-alpine -f answers<enter><wait5>",
         "vagrant<enter>",
@@ -45,37 +19,36 @@
         "sed -i -E 's,#?(PermitRootLogin\\s+).+,\\1yes,' /mnt/etc/ssh/sshd_config<enter>",
         "reboot<enter>"
       ],
-      "shutdown_command": "poweroff"
-    },
-    {
-      "name": "alpine-{{user `version`}}-amd64-virtualbox",
-      "type": "virtualbox-iso",
-      "guest_os_type": "Linux26_64",
-      "guest_additions_mode": "attach",
+      "boot_wait": "30s",
+      "disk_discard": "unmap",
+      "disk_interface": "virtio-scsi",
+      "disk_size": "{{user `disk_size`}}",
+      "format": "qcow2",
       "headless": true,
       "http_directory": ".",
-      "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--memory", "2048"],
-        ["modifyvm", "{{.Name}}", "--cpus", "2"],
-        ["modifyvm", "{{.Name}}", "--vram", "32"],
-        ["modifyvm", "{{.Name}}", "--nictype1", "virtio"],
-        ["modifyvm", "{{.Name}}", "--nictype2", "virtio"],
-        ["modifyvm", "{{.Name}}", "--nictype3", "virtio"],
-        ["modifyvm", "{{.Name}}", "--nictype4", "virtio"]
-      ],
-      "disk_size": "{{user `disk_size`}}",
-      "hard_drive_interface": "sata",
-      "hard_drive_discard": true,
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
       "iso_url": "{{user `iso_url`}}",
-      "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "{{user `iso_checksum_type`}}",
-      "ssh_username": "root",
+      "name": "alpine-{{user `version`}}-amd64-libvirt",
+      "qemuargs": [
+        [
+          "-m",
+          "2048"
+        ],
+        [
+          "-smp",
+          "2"
+        ]
+      ],
+      "shutdown_command": "poweroff",
       "ssh_password": "vagrant",
-      "ssh_wait_timeout": "60m",
-      "boot_wait": "30s",
+      "ssh_timeout": "60m",
+      "ssh_username": "root",
+      "type": "qemu"
+    },
+    {
       "boot_command": [
         "root<enter>",
-        "ifconfig eth0 up && udhcpc -i eth0<enter><wait5>",
+        "ifconfig eth0 up \u0026\u0026 udhcpc -i eth0<enter><wait5>",
         "wget -q http://{{.HTTPIP}}:{{.HTTPPort}}/answers<enter><wait>",
         "setup-alpine -f $PWD/answers<enter><wait5>",
         "vagrant<enter>",
@@ -90,21 +63,90 @@
         "sed -i -E 's,#?(PermitRootLogin\\s+).+,\\1yes,' /mnt/etc/ssh/sshd_config<enter>",
         "reboot<enter>"
       ],
-      "shutdown_command": "poweroff"
-    }
-  ],
-  "provisioners": [
-    {
-      "type": "shell",
-      "execute_command": "sh {{.Path}}",
-      "scripts": ["provision.sh"]
+      "boot_wait": "30s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_additions_mode": "attach",
+      "guest_os_type": "Linux26_64",
+      "hard_drive_discard": true,
+      "hard_drive_interface": "sata",
+      "headless": true,
+      "http_directory": ".",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "name": "alpine-{{user `version`}}-amd64-virtualbox",
+      "shutdown_command": "poweroff",
+      "ssh_password": "vagrant",
+      "ssh_timeout": "60m",
+      "ssh_username": "root",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "2"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "32"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--nictype1",
+          "virtio"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--nictype2",
+          "virtio"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--nictype3",
+          "virtio"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--nictype4",
+          "virtio"
+        ]
+      ]
     }
   ],
   "post-processors": [
     {
-      "type": "vagrant",
       "output": "{{.BuildName}}.box",
+      "type": "vagrant",
       "vagrantfile_template": "Vagrantfile.template"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "execute_command": "sh {{.Path}}",
+      "scripts": [
+        "provision.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "disk_size": "20480",
+    "iso_checksum": "c197f9cf095178d5ae978a47597a4004c16c879d2047b9906f91642cb01c2ef9",
+    "iso_checksum_type": "sha256",
+    "iso_url": "http://dl-cdn.alpinelinux.org/alpine/v3.13/releases/x86_64/alpine-standard-3.13.0-x86_64.iso",
+    "version": "3.13"
+  }
 }
+

--- a/answers
+++ b/answers
@@ -9,7 +9,7 @@ iface eth0 inet dhcp
 DNSOPTS=""
 TIMEZONEOPTS="-z UTC"
 PROXYOPTS="none"
-APKREPOSOPTS="http://mirrors.dotsrc.org/alpine/v3.12/main"
+APKREPOSOPTS="http://mirrors.dotsrc.org/alpine/v3.13/main"
 SSHDOPTS="-c openssh"
 NTPOPTS="-c chrony"
 DISKOPTS="-s 0 -m sys /dev/sda"

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = 'alpine-3.12-amd64'
+  config.vm.box = 'alpine-3.13-amd64'
 
   config.vm.hostname = 'example.test'
 

--- a/provision.sh
+++ b/provision.sh
@@ -27,14 +27,14 @@ chown -R vagrant:vagrant /home/vagrant/.ssh
 # install the Guest Additions.
 if [ "$(cat /sys/devices/virtual/dmi/id/board_name)" == 'VirtualBox' ]; then
 # install the VirtualBox Guest Additions.
-echo http://mirrors.dotsrc.org/alpine/v3.12/community >>/etc/apk/repositories
+echo http://mirrors.dotsrc.org/alpine/v3.13/community >>/etc/apk/repositories
 apk add -U virtualbox-guest-additions virtualbox-guest-modules-lts
 rc-update add virtualbox-guest-additions
 echo vboxsf >>/etc/modules
 modinfo vboxguest
 else
 # install the qemu-kvm Guest Additions.
-echo http://mirrors.dotsrc.org/alpine/v3.12/community >>/etc/apk/repositories
+echo http://mirrors.dotsrc.org/alpine/v3.13/community >>/etc/apk/repositories
 apk add -U qemu-guest-agent
 rc-update add qemu-guest-agent
 # configure the GA_PATH, as, for some reason, its at /dev/vport0p1 instead of

--- a/provision.sh
+++ b/provision.sh
@@ -28,7 +28,8 @@ chown -R vagrant:vagrant /home/vagrant/.ssh
 if [ "$(cat /sys/devices/virtual/dmi/id/board_name)" == 'VirtualBox' ]; then
 # install the VirtualBox Guest Additions.
 echo http://mirrors.dotsrc.org/alpine/v3.13/community >>/etc/apk/repositories
-apk add -U virtualbox-guest-additions virtualbox-guest-modules-lts
+apk add -U virtualbox-guest-additions
+# virtualbox-guest-modules-lts
 rc-update add virtualbox-guest-additions
 echo vboxsf >>/etc/modules
 modinfo vboxguest


### PR DESCRIPTION
Packer 1.6.6 had a problem which necessitated updating the template
via e.g. `packer fix alpine.json > new.json`

Details:
```2021/01/27 23:16:55 Build 'alpine-3.13-amd64-virtualbox' prepare failure: 1 error occurred:
Error: Failed to prepare build: "alpine-3.13-amd64-virtualbox"
1 error occurred:
        * Deprecated configuration key: 'iso_checksum_type'. Please call `packer fix`
against your template to update your template to be compatible with the current
version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more
detail.
```